### PR TITLE
Fix GHC 8.2 build

### DIFF
--- a/src/System/Win32/FileNotify.hsc
+++ b/src/System/Win32/FileNotify.hsc
@@ -62,10 +62,12 @@ faToAction fa = toEnum $ fromEnum fa - 1
 -- Defined in System.Win32.File, but with too few cases:
 -- type AccessMode = UINT
 
+#if !(MIN_VERSION_Win32(2,4,0))
 #{enum AccessMode,
  , fILE_LIST_DIRECTORY = FILE_LIST_DIRECTORY
  }
 -- there are many more cases but I only need this one.
+#endif
 
 type FileAction = DWORD
 


### PR DESCRIPTION
`Win32-2.4.0` introduced both `AccessMode` and `fILE_LIST_DIRECTORY`, and the locally defined versions of these in `Win32-notify` clash with them, causing the library to fail to build on GHC 8.2.1. This adds the appropriate CPP to fix the build.